### PR TITLE
Making Drupal Framework Install not fail when a mail system doesn't exist

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -3,7 +3,7 @@
 set -e
 path=$(dirname "$0")
 base=$(cd $path/.. && pwd)
-drush="$base/vendor/bin/drush.php $drush_flags -y -r $base/www"
+drush="$base/vendor/bin/drush $drush_flags -y -r $base/www"
 
 if [[ -f .env ]]; then 
   source .env

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -e
 path=$(dirname "$0")
+true=`which true`
 source $path/common.sh
 
 echo "Installing Drupal minimal profile.";
-$drush si minimal --account-name=admin --account-pass=drupaladm1n
+# Setting PHP Options so that we don't fail while sending mail if a mail sytem
+# doesn't exist.
+PHP_OPTIONS="-d sendmail_path=$true" $drush si minimal --account-name=admin --account-pass=drupaladm1n
 source $path/update.sh


### PR DESCRIPTION
By setting send mail to true for the one command, we are circumventing drupal install from failing because there is no way to set the mail system before install however, drupal does send an email to the site administrator in order to let them know that a new version is ready of drupal.

Also switching drush.php to drush so that we can use the robustness of the already existing bashscript to run drush.
