### PR TITLE
Removing "registry_rebuild" from the dependencies list on default.info

### DIFF
--- a/default.info
+++ b/default.info
@@ -13,7 +13,6 @@ dependencies[] = features
 dependencies[] = feeds
 dependencies[] = kw_manifests
 dependencies[] = module_filter
-dependencies[] = registry_rebuild
 dependencies[] = rules
 dependencies[] = strongarm
 dependencies[] = views


### PR DESCRIPTION
If this is used as a template for your project's base file, it causes an endless loop during the vagrant up process.