### PR TITLE
Gitignore the /build/ref reference database directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/ref
 cnf/config.yml
 cnf/settings.php
 www


### PR DESCRIPTION
Probably want to gitignore /build/ref to avoid ever accidentally committing a reference database.