### PR TITLE
Update composer related files mainly for drupal wysiwyg module.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,30 @@
                     "files": ["simple_html_dom.php"]
                 }
             }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "promet/drupal-wysiwyg-patched",
+                "version": "1.0.0",
+                "type": "patches",
+                "require": {
+                    "netresearch/composer-patches-plugin": "~1.0",
+                    "drupal/wysiwyg": "7.2.2"
+                },
+                "extra": {
+                    "patches": {
+                        "drupal/wysiwyg": {
+                          "7.2.2": [
+                                {
+                                    "title": "Ckeditor 4.0 - The version of CKEditor could not be detected.",
+                                    "url": "https://www.drupal.org/files/wysiwyg-ckeditor4-1853550-4.patch"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
         }
     ],
     "require": {
@@ -109,8 +133,8 @@
         "drupal/rules": "7.*",
         "drupal/strongarm": "7.*",
         "drupal/views": "7.*",
-        "drupal/wysiwyg": "7.*",
         "drush/drush": "6.*",
+        "promet/drupal-wysiwyg-patched": "~1.0",
         "winmillwill/settings_compile": "~2.1.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a64078431004f7c06e4a7a91fe04acf1",
+    "hash": "9a1282adc823f567124df1cd05459161",
     "packages": [
         {
             "name": "ckeditor/ckeditor",
@@ -295,39 +295,40 @@
         },
         {
             "name": "drupal/drop_ship",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/promet/drop_ship.git",
-                "reference": "62c302b801c64c6e968a4523e065940cf096b0e7"
+                "reference": "3e8059080498905c64729c0908c1aba8379250bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/promet/drop_ship/zipball/62c302b801c64c6e968a4523e065940cf096b0e7",
-                "reference": "62c302b801c64c6e968a4523e065940cf096b0e7",
+                "url": "https://api.github.com/repos/promet/drop_ship/zipball/3e8059080498905c64729c0908c1aba8379250bd",
+                "reference": "3e8059080498905c64729c0908c1aba8379250bd",
                 "shasum": ""
             },
             "require": {
+                "drupal/features": "~7.2.2",
                 "drupal/kw_manifests": "1.*"
             },
             "type": "drupal-module",
             "support": {
-                "source": "https://github.com/promet/drop_ship/tree/1.0.2",
+                "source": "https://github.com/promet/drop_ship/tree/1.0.3",
                 "issues": "https://github.com/promet/drop_ship/issues"
             },
-            "time": "2014-08-15 01:41:09"
+            "time": "2015-05-12 19:55:23"
         },
         {
             "name": "drupal/drupal",
-            "version": "7.36.0",
+            "version": "7.37.0",
             "source": {
                 "type": "git",
                 "url": "http://git.drupal.org/project/drupal",
-                "reference": "dec44e119e058eb9b48b81f5f1cc80592270e23c"
+                "reference": "fb7030c7db879b76a23a07df593bb4ba29547724"
             },
             "dist": {
                 "type": "zip",
-                "url": "http://ftp.drupal.org/files/projects/drupal-7.36.zip",
+                "url": "http://ftp.drupal.org/files/projects/drupal-7.37.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -484,85 +485,35 @@
             "description": "Enables modules to work with any entity type and to provide entities."
         },
         {
-            "name": "drupal/entity2text",
-            "version": "7.1.0-alpha2",
-            "source": {
-                "type": "git",
-                "url": "http://git.drupal.org/project/entity2text",
-                "reference": "b407d74ecb8599a46b78cbdfe9e8e71963babfc8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "http://ftp.drupal.org/files/projects/entity2text-7.x-1.0-alpha2.zip",
-                "reference": null,
-                "shasum": null
-            },
-            "require": {
-                "drupal/drupal": "7.*",
-                "drupal/entity": "7.*",
-                "drupal/entity_token": "7.*"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-7.x-1.x": "7.1.x-dev"
-                }
-            },
-            "description": "Provides API and Tokens for Rendering Entities to plain text"
-        },
-        {
-            "name": "drupal/entity_rules",
-            "version": "7.1.0-alpha4",
-            "source": {
-                "type": "git",
-                "url": "http://git.drupal.org/project/entity_rules",
-                "reference": "a595d5f066086fb0c42cc7a0ed025eddcbce6e68"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "http://ftp.drupal.org/files/projects/entity_rules-7.x-1.0-alpha4.zip",
-                "reference": null,
-                "shasum": null
-            },
-            "require": {
-                "drupal/drupal": "7.*",
-                "drupal/entity": "7.*",
-                "drupal/rules": "7.*"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-7.x-1.x": "7.1.x-dev"
-                }
-            },
-            "description": "Provides UI for select Rules to execute during Entity Events"
-        },
-        {
             "name": "drupal/entityform",
-            "version": "7.2.0-rc1",
+            "version": "7.2.0-rc2",
             "source": {
                 "type": "git",
                 "url": "http://git.drupal.org/project/entityform",
-                "reference": "cddff9d3206f2b4716fbe3f5cdac90da28c1b6bb"
+                "reference": "ab1e99512782a2bcdbec9491f435442f41b25a22"
             },
             "dist": {
                 "type": "zip",
-                "url": "http://ftp.drupal.org/files/projects/entityform-7.x-2.0-rc1.zip",
+                "url": "http://ftp.drupal.org/files/projects/entityform-7.x-2.0-rc2.zip",
                 "reference": null,
                 "shasum": null
             },
             "require": {
                 "drupal/drupal": "7.*",
                 "drupal/entity": "7.*",
-                "drupal/entity2text": "7.*",
-                "drupal/entity_rules": "7.*",
-                "drupal/rules": "7.*",
-                "drupal/session_api": "7.*",
                 "drupal/views": "7.*"
             },
             "replace": {
                 "drupal/entityform_anonymous": "self.version",
+                "drupal/entityform_i18n": "self.version",
                 "drupal/entityform_notifications": "self.version"
+            },
+            "suggest": {
+                "drupal/entity2text": "Required by drupal/entityform_notifications",
+                "drupal/entity_rules": "Required by drupal/entityform_notifications",
+                "drupal/i18n_string": "Required by drupal/entityform_i18n",
+                "drupal/rules": "Required by drupal/entityform_notifications",
+                "drupal/session_api": "Required by drupal/entityform_anonymous"
             },
             "type": "drupal-module",
             "extra": {
@@ -570,19 +521,20 @@
                     "dev-7.x-2.x": "7.2.x-dev"
                 }
             },
+            "notification-url": "http://packagist.drupal-composer.org/downloads/",
             "description": "Provides fieldable entity forms"
         },
         {
             "name": "drupal/features",
-            "version": "7.2.5",
+            "version": "7.2.6-rc1",
             "source": {
                 "type": "git",
                 "url": "http://git.drupal.org/project/features",
-                "reference": "14fa81e5c4c6016a33484d147d59bd5033619875"
+                "reference": "21213ad9017fcc633b8111cb9439e82cf6baf5d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "http://ftp.drupal.org/files/projects/features-7.x-2.5.zip",
+                "url": "http://ftp.drupal.org/files/projects/features-7.x-2.6-rc1.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -596,7 +548,8 @@
                 }
             },
             "notification-url": "http://packagist.drupal-composer.org/downloads/",
-            "description": "Provides feature management for Drupal."
+            "description": "Provides feature management for Drupal.",
+            "homepage": "https://www.drupal.org/project/features"
         },
         {
             "name": "drupal/feeds",
@@ -837,31 +790,6 @@
             "description": "React on events and conditionally evaluate actions."
         },
         {
-            "name": "drupal/session_api",
-            "version": "7.1.0-rc1",
-            "source": {
-                "type": "git",
-                "url": "http://git.drupal.org/project/session_api",
-                "reference": "639110648309c99579bf12503f4362d95b509a37"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "http://ftp.drupal.org/files/projects/session_api-7.x-1.0-rc1.zip",
-                "reference": null,
-                "shasum": null
-            },
-            "require": {
-                "drupal/drupal": "7.*"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-7.x-1.x": "7.1.x-dev"
-                }
-            },
-            "description": "Provides an interface for storing session information."
-        },
-        {
             "name": "drupal/strongarm",
             "version": "7.2.0",
             "source": {
@@ -921,15 +849,15 @@
         },
         {
             "name": "drupal/views",
-            "version": "7.3.10",
+            "version": "7.3.11",
             "source": {
                 "type": "git",
                 "url": "http://git.drupal.org/project/views",
-                "reference": "f4e8b47ff8adecbb00eb921a978dfe0b6a278539"
+                "reference": "cef693bc5874d75659bbcb03f77fc7ecf106be97"
             },
             "dist": {
                 "type": "zip",
-                "url": "http://ftp.drupal.org/files/projects/views-7.x-3.10.zip",
+                "url": "http://ftp.drupal.org/files/projects/views-7.x-3.11.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -1106,6 +1034,77 @@
             "time": "2015-03-27 16:41:39"
         },
         {
+            "name": "netresearch/composer-patches-plugin",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/netresearch/composer-patches-plugin.git",
+                "reference": "41798117c1e5ff66ac696628bce4696115a965e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/netresearch/composer-patches-plugin/zipball/41798117c1e5ff66ac696628bce4696115a965e1",
+                "reference": "41798117c1e5ff66ac696628bce4696115a965e1",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "1.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "1.*"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Netresearch\\Composer\\Patches\\Plugin",
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Opitz",
+                    "email": "christian.opitz@netresearch.de"
+                }
+            ],
+            "description": "Composer patches plugin",
+            "keywords": [
+                "composer",
+                "patches",
+                "plugin"
+            ],
+            "time": "2014-05-12 11:29:27"
+        },
+        {
+            "name": "promet/drupal-wysiwyg-patched",
+            "version": "1.0.0",
+            "require": {
+                "drupal/wysiwyg": "7.2.2",
+                "netresearch/composer-patches-plugin": "~1.0"
+            },
+            "type": "patches",
+            "extra": {
+                "patches": {
+                    "drupal/wysiwyg": {
+                        "7.2.2": [
+                            {
+                                "title": "Ckeditor 4.0 - The version of CKEditor could not be detected.",
+                                "url": "https://www.drupal.org/files/wysiwyg-ckeditor4-1853550-4.patch"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
             "name": "seld/jsonlint",
             "version": "1.3.1",
             "source": {
@@ -1153,17 +1152,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/Config",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Config.git",
-                "reference": "0c5eef5e427796dc2213def299e48bff7ab90cd0"
+                "reference": "537e9912063e66aa70cbcddd7d6e6e8db61d98e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/0c5eef5e427796dc2213def299e48bff7ab90cd0",
-                "reference": "0c5eef5e427796dc2213def299e48bff7ab90cd0",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/537e9912063e66aa70cbcddd7d6e6e8db61d98e4",
+                "reference": "537e9912063e66aa70cbcddd7d6e6e8db61d98e4",
                 "shasum": ""
             },
             "require": {
@@ -1180,7 +1178,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Config\\": ""
                 }
             },
@@ -1190,31 +1188,30 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Config Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 13:54:53"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-15 13:33:16"
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/Console",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "7a8b8e2b82827622ef60127547bc3c7ce2e18982"
+                "reference": "7f0bec04961c61c961df0cb8c2ae88dbfd83f399"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/7a8b8e2b82827622ef60127547bc3c7ce2e18982",
-                "reference": "7a8b8e2b82827622ef60127547bc3c7ce2e18982",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/7f0bec04961c61c961df0cb8c2ae88dbfd83f399",
+                "reference": "7f0bec04961c61c961df0cb8c2ae88dbfd83f399",
                 "shasum": ""
             },
             "require": {
@@ -1238,7 +1235,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Console\\": ""
                 }
             },
@@ -1248,31 +1245,30 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Console Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 15:31:32"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-29 16:22:24"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/Filesystem",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "66a39e7cb4d83417fdc4c3eb451df5e575a7221f"
+                "reference": "ae4551fd6d4d4f51f2e7390fbc902fbd67f3b7ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/66a39e7cb4d83417fdc4c3eb451df5e575a7221f",
-                "reference": "66a39e7cb4d83417fdc4c3eb451df5e575a7221f",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/ae4551fd6d4d4f51f2e7390fbc902fbd67f3b7ba",
+                "reference": "ae4551fd6d4d4f51f2e7390fbc902fbd67f3b7ba",
                 "shasum": ""
             },
             "require": {
@@ -1288,7 +1284,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
                 }
             },
@@ -1298,31 +1294,30 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Filesystem Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-15 13:33:16"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/Finder",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Finder.git",
-                "reference": "3e0b09269a91264201517df15ca753e9b9329a9b"
+                "reference": "ccb8ed8339cf24824f2ef35dacec30d92ff44368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/3e0b09269a91264201517df15ca753e9b9329a9b",
-                "reference": "3e0b09269a91264201517df15ca753e9b9329a9b",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/ccb8ed8339cf24824f2ef35dacec30d92ff44368",
+                "reference": "ccb8ed8339cf24824f2ef35dacec30d92ff44368",
                 "shasum": ""
             },
             "require": {
@@ -1338,7 +1333,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
                 }
             },
@@ -1348,31 +1343,30 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Finder Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-15 14:02:48"
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/Process",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Process.git",
-                "reference": "2930a2b76a5dde9ca8480714679fffb29bb304b5"
+                "reference": "e0a82b58e36afc60f8e79b8bc85a22bb064077c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/2930a2b76a5dde9ca8480714679fffb29bb304b5",
-                "reference": "2930a2b76a5dde9ca8480714679fffb29bb304b5",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/e0a82b58e36afc60f8e79b8bc85a22bb064077c1",
+                "reference": "e0a82b58e36afc60f8e79b8bc85a22bb064077c1",
                 "shasum": ""
             },
             "require": {
@@ -1388,7 +1382,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Process\\": ""
                 }
             },
@@ -1398,31 +1392,30 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Process Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-15 13:33:16"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "43e7bee10c88f23252ee1b6b25140dc9917c3d96"
+                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/43e7bee10c88f23252ee1b6b25140dc9917c3d96",
-                "reference": "43e7bee10c88f23252ee1b6b25140dc9917c3d96",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4a29a5248aed4fb45f626a7bbbd330291492f5c3",
+                "reference": "4a29a5248aed4fb45f626a7bbbd330291492f5c3",
                 "shasum": ""
             },
             "require": {
@@ -1438,7 +1431,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
                 }
             },
@@ -1448,17 +1441,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Yaml Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:21:08"
         },
         {
             "name": "winmillwill/settings_compile",
@@ -1955,15 +1948,15 @@
         },
         {
             "name": "drupal/backup_migrate",
-            "version": "7.3.0",
+            "version": "7.3.1",
             "source": {
                 "type": "git",
                 "url": "http://git.drupal.org/project/backup_migrate",
-                "reference": "eb014f95c494f857fba12c1f326ad60afd5a9383"
+                "reference": "174bb364b71887a23140efea626d2843b57bd4cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "http://ftp.drupal.org/files/projects/backup_migrate-7.x-3.0-alpha1.zip",
+                "url": "http://ftp.drupal.org/files/projects/backup_migrate-7.x-3.1.zip",
                 "reference": null,
                 "shasum": null
             },
@@ -2317,12 +2310,12 @@
             "target-dir": "Guzzle/Common",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/common.git",
+                "url": "https://github.com/Guzzle3/common.git",
                 "reference": "2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/common/zipball/2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc",
+                "url": "https://api.github.com/repos/Guzzle3/common/zipball/2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc",
                 "reference": "2e36af7cf2ce3ea1f2d7c2831843b883a8e7b7dc",
                 "shasum": ""
             },
@@ -2361,12 +2354,12 @@
             "target-dir": "Guzzle/Http",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/http.git",
+                "url": "https://github.com/Guzzle3/http.git",
                 "reference": "1e8dd1e2ba9dc42332396f39fbfab950b2301dc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/http/zipball/1e8dd1e2ba9dc42332396f39fbfab950b2301dc5",
+                "url": "https://api.github.com/repos/Guzzle3/http/zipball/1e8dd1e2ba9dc42332396f39fbfab950b2301dc5",
                 "reference": "1e8dd1e2ba9dc42332396f39fbfab950b2301dc5",
                 "shasum": ""
             },
@@ -2418,12 +2411,12 @@
             "target-dir": "Guzzle/Parser",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/parser.git",
+                "url": "https://github.com/Guzzle3/parser.git",
                 "reference": "6874d171318a8e93eb6d224cf85e4678490b625c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/parser/zipball/6874d171318a8e93eb6d224cf85e4678490b625c",
+                "url": "https://api.github.com/repos/Guzzle3/parser/zipball/6874d171318a8e93eb6d224cf85e4678490b625c",
                 "reference": "6874d171318a8e93eb6d224cf85e4678490b625c",
                 "shasum": ""
             },
@@ -2462,12 +2455,12 @@
             "target-dir": "Guzzle/Stream",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/stream.git",
+                "url": "https://github.com/Guzzle3/stream.git",
                 "reference": "60c7fed02e98d2c518dae8f97874c8f4622100f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/stream/zipball/60c7fed02e98d2c518dae8f97874c8f4622100f0",
+                "url": "https://api.github.com/repos/Guzzle3/stream/zipball/60c7fed02e98d2c518dae8f97874c8f4622100f0",
                 "reference": "60c7fed02e98d2c518dae8f97874c8f4622100f0",
                 "shasum": ""
             },
@@ -2569,16 +2562,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.0.16",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c"
+                "reference": "3703c4bb67c8700957dd41c843254658539d091d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/934fd03eb6840508231a7f73eb8940cf32c3b66c",
-                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/3703c4bb67c8700957dd41c843254658539d091d",
+                "reference": "3703c4bb67c8700957dd41c843254658539d091d",
                 "shasum": ""
             },
             "require": {
@@ -2601,7 +2594,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -2627,7 +2620,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-04-11 04:35:00"
+            "time": "2015-06-06 08:33:23"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2887,16 +2880,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.1",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c"
+                "reference": "253c005852591fd547fc18cd5b7b43a1ec82d8f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/74ffb87f527f24616f72460e54b595f508dccb5c",
-                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/253c005852591fd547fc18cd5b7b43a1ec82d8f7",
+                "reference": "253c005852591fd547fc18cd5b7b43a1ec82d8f7",
                 "shasum": ""
             },
             "require": {
@@ -2938,7 +2931,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-04-02 05:36:41"
+            "time": "2015-05-29 05:19:18"
         },
         {
             "name": "sebastian/comparator",
@@ -3355,17 +3348,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/BrowserKit",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/BrowserKit.git",
-                "reference": "4bc76eb9201878e575af0a7954df2acc8509cb08"
+                "reference": "70cdc18dd601a486a8cc69ee26367cbaedd60400"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/BrowserKit/zipball/4bc76eb9201878e575af0a7954df2acc8509cb08",
-                "reference": "4bc76eb9201878e575af0a7954df2acc8509cb08",
+                "url": "https://api.github.com/repos/symfony/BrowserKit/zipball/70cdc18dd601a486a8cc69ee26367cbaedd60400",
+                "reference": "70cdc18dd601a486a8cc69ee26367cbaedd60400",
                 "shasum": ""
             },
             "require": {
@@ -3387,7 +3379,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\BrowserKit\\": ""
                 }
             },
@@ -3397,31 +3389,30 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony BrowserKit Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:21:08"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/CssSelector",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/CssSelector.git",
-                "reference": "5ce43b14eb8c35268413f7f3ecb9e3ca3dd6dfb1"
+                "reference": "0b5c07b516226b7dd32afbbc82fe547a469c5092"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/CssSelector/zipball/5ce43b14eb8c35268413f7f3ecb9e3ca3dd6dfb1",
-                "reference": "5ce43b14eb8c35268413f7f3ecb9e3ca3dd6dfb1",
+                "url": "https://api.github.com/repos/symfony/CssSelector/zipball/0b5c07b516226b7dd32afbbc82fe547a469c5092",
+                "reference": "0b5c07b516226b7dd32afbbc82fe547a469c5092",
                 "shasum": ""
             },
             "require": {
@@ -3437,7 +3428,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\CssSelector\\": ""
                 }
             },
@@ -3447,35 +3438,34 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Jean-François Simon",
                     "email": "jeanfrancois.simon@sensiolabs.com"
                 },
                 {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony CssSelector Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-15 13:33:16"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/DependencyInjection",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/DependencyInjection.git",
-                "reference": "bd7d379ed60a60abd8d32a3260160abbac8c9efa"
+                "reference": "137bf489c5151c7eb1e4b7dd34a123f9a74b966d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/bd7d379ed60a60abd8d32a3260160abbac8c9efa",
-                "reference": "bd7d379ed60a60abd8d32a3260160abbac8c9efa",
+                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/137bf489c5151c7eb1e4b7dd34a123f9a74b966d",
+                "reference": "137bf489c5151c7eb1e4b7dd34a123f9a74b966d",
                 "shasum": ""
             },
             "require": {
@@ -3502,7 +3492,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\DependencyInjection\\": ""
                 }
             },
@@ -3512,31 +3502,30 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony DependencyInjection Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-29 14:44:44"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/DomCrawler",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/DomCrawler.git",
-                "reference": "30ab7e697ffd022eb2cdffaa67825d04109cdaaf"
+                "reference": "11d8eb8ccc1533f4c2d89a025f674894fda520b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DomCrawler/zipball/30ab7e697ffd022eb2cdffaa67825d04109cdaaf",
-                "reference": "30ab7e697ffd022eb2cdffaa67825d04109cdaaf",
+                "url": "https://api.github.com/repos/symfony/DomCrawler/zipball/11d8eb8ccc1533f4c2d89a025f674894fda520b3",
+                "reference": "11d8eb8ccc1533f4c2d89a025f674894fda520b3",
                 "shasum": ""
             },
             "require": {
@@ -3556,7 +3545,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\DomCrawler\\": ""
                 }
             },
@@ -3566,31 +3555,30 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony DomCrawler Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-22 14:54:25"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/EventDispatcher",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "28008406abd5385496fb2cb79bdd0f8b8a8bd44d"
+                "reference": "687039686d0e923429ba6e958d0baa920cd5d458"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/28008406abd5385496fb2cb79bdd0f8b8a8bd44d",
-                "reference": "28008406abd5385496fb2cb79bdd0f8b8a8bd44d",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/687039686d0e923429ba6e958d0baa920cd5d458",
+                "reference": "687039686d0e923429ba6e958d0baa920cd5d458",
                 "shasum": ""
             },
             "require": {
@@ -3615,7 +3603,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
                 }
             },
@@ -3625,31 +3613,30 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony EventDispatcher Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:21:08"
         },
         {
             "name": "symfony/translation",
-            "version": "v2.7.0-BETA1",
-            "target-dir": "Symfony/Component/Translation",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Translation.git",
-                "reference": "7ecdcceff51b57d87ff3e262e4069f902a720a0b"
+                "reference": "cc1907bbeacfcc703c031b67545400d6e7d1eb79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/7ecdcceff51b57d87ff3e262e4069f902a720a0b",
-                "reference": "7ecdcceff51b57d87ff3e262e4069f902a720a0b",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/cc1907bbeacfcc703c031b67545400d6e7d1eb79",
+                "reference": "cc1907bbeacfcc703c031b67545400d6e7d1eb79",
                 "shasum": ""
             },
             "require": {
@@ -3677,7 +3664,7 @@
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Translation\\": ""
                 }
             },
@@ -3687,17 +3674,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Translation Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-10 07:23:38"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-29 14:44:44"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Added custom package to serve as the patch for Drupal's WYSIWYG
module. The patch mainly fixes the detection of the CKEditor
library's version.

Ran composer update w/c resulted to the inclusion of the patch
and was able to update some modules to its stable state.

Additional info on the update output:
```
Loading composer repositories with package information
Updating dependencies (including require-dev)            
  - Removing drupal/entity2text (7.1.0-alpha2)
  - Removing drupal/entity_rules (7.1.0-alpha4)
  - Removing drupal/session_api (7.1.0-rc1)
  - Removing drupal/drupal (7.36.0)
  - Installing drupal/drupal (7.37.0)
    Downloading: 100%         

  - Removing drupal/features (7.2.5)
  - Installing drupal/features (7.2.6-rc1)
    Downloading: 100%         

  - Removing drupal/drop_ship (1.0.2)
  - Installing drupal/drop_ship (1.0.3)
    Downloading: 100%         

  - Removing drupal/views (7.3.10)
  - Installing drupal/views (7.3.11)
    Downloading: 100%         

  - Removing drupal/entityform (7.2.0-rc1)
  - Installing drupal/entityform (7.2.0-rc2)
    Downloading: 0%           
```
Interrupted and continued the update
```
Loading composer repositories with package information
Updating dependencies (including require-dev)            
  - Removing drupal/backup_migrate (7.3.0)
  - Installing drupal/backup_migrate (7.3.1)
    Downloading: 100%         

  - Removing symfony/console (v2.7.0-BETA1)
  - Installing symfony/console (v2.7.0)
    Downloading: 100%         

  - Removing symfony/finder (v2.7.0-BETA1)
  - Installing symfony/finder (v2.7.0)
    Downloading: 100%         

  - Removing symfony/process (v2.7.0-BETA1)
  - Installing symfony/process (v2.7.0)
    Downloading: 100%         

  - Removing symfony/filesystem (v2.7.0-BETA1)
  - Installing symfony/filesystem (v2.7.0)
    Downloading: 100%         

  - Removing symfony/config (v2.7.0-BETA1)
  - Installing symfony/config (v2.7.0)
    Downloading: 100%         

  - Removing symfony/yaml (v2.7.0-BETA1)
  - Installing symfony/yaml (v2.7.0)
    Downloading: 100%         

  - Removing symfony/css-selector (v2.7.0-BETA1)
  - Installing symfony/css-selector (v2.7.0)
    Downloading: 100%         

  - Removing symfony/dependency-injection (v2.7.0-BETA1)
  - Installing symfony/dependency-injection (v2.7.0)
    Downloading: 100%         

  - Removing symfony/event-dispatcher (v2.7.0-BETA1)
  - Installing symfony/event-dispatcher (v2.7.0)
    Downloading: 100%         

  - Removing symfony/translation (v2.7.0-BETA1)
  - Installing symfony/translation (v2.7.0)
    Downloading: 100%         

  - Removing phpunit/php-code-coverage (2.0.16)
  - Installing phpunit/php-code-coverage (2.1.4)
    Downloading: 100%         

  - Removing phpunit/phpunit-mock-objects (2.3.1)
  - Installing phpunit/phpunit-mock-objects (2.3.3)
    Downloading: 100%         

  - Removing symfony/dom-crawler (v2.7.0-BETA1)
  - Installing symfony/dom-crawler (v2.7.0)
    Downloading: 100%         

  - Removing symfony/browser-kit (v2.7.0-BETA1)
  - Installing symfony/browser-kit (v2.7.0)
    Downloading: 100%         

  - Installing drupal/entityform (7.2.0-rc2)
    Downloading: 0%    Failed to download drupal/entityform from dist: The "http://ftp.drupal.org/files/projects/entityform-7.x-2.0-rc2.zip" file could not be downloaded (HTTP/1.1 404 Not Found)
    Now trying to download from source
  - Installing drupal/entityform (7.2.0-rc2)
    Cloning ab1e99512782a2bcdbec9491f435442f41b25a22

drupal/entityform suggests installing drupal/session_api (Required by drupal/entityform_anonymous)
drupal/entityform suggests installing drupal/i18n_string (Required by drupal/entityform_i18n)
drupal/entityform suggests installing drupal/entity_rules (Required by drupal/entityform_notifications)
drupal/entityform suggests installing drupal/entity2text (Required by drupal/entityform_notifications)
Writing lock file
Generating autoload files
```
Don't know why the new package wasn't included but just ran the update again from here.
```
Loading composer repositories with package information
Updating dependencies (including require-dev)            
  - Installing netresearch/composer-patches-plugin (1.0.1)
    Downloading: 100%         

Writing lock file
Generating autoload files
    Downloading: 100%         
  - Applying patch to drupal/wysiwyg: Ckeditor 4.0 - The version of CKEditor could not be detected.
```