### PR TITLE
Add updb to the beginning of builds

### DIFF
--- a/build/update.sh
+++ b/build/update.sh
@@ -2,7 +2,11 @@
 set -e
 path=$(dirname "$0")
 source $path/common.sh
-
+# This was added because of upgrades like Rules 2.8 to 2.9 and Feeds alpha-9 to beta-1 where
+# new code and database tables are added and running other code will cause white screen until
+# the updates are run.
+echo "Initial Update so updated modules can work.";
+$drush updb -y;
 echo "Enabling modules";
 $drush en $(echo $DROPSHIP_SEEDS | tr ':' ' ')
 echo "Rebuilding registry and clearing caches.";


### PR DESCRIPTION
This allows modules (mostly contributed) to run updates that require updates before the new code can be run. This includes a couple of popular ones like feeds and rules.