### PR TITLE
Set secure-http to false, to access drupal git repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,5 +74,8 @@
         "post-update-cmd": [
             "Drupal\\Tangler\\ScriptHandler::postUpdate"
         ]
+    },
+    "config":{
+        "secure-http": false
     }
 }


### PR DESCRIPTION
This is necessary for composer to download from http domain